### PR TITLE
Testing new TTS

### DIFF
--- a/services/moshi-server/configs/tts-py.toml
+++ b/services/moshi-server/configs/tts-py.toml
@@ -14,7 +14,11 @@ text_bos_token = 1
 
 [modules.tts_py.py]
 log_folder = "/logs"
-moshi_weight = "/models/tts_2961f6b6@82/checkpoint.safetensors"
-config_path = "/models/tts_2961f6b6@82/config.json"
-voice_folder = "/models/"
+moshi_weight = "/models/moshi/moshi_d9876fea_500/checkpoint.safetensors"
+config_path = "/models/moshi/moshi_d9876fea_500/config.json"
+tokenizer = "/models/test_en_fr_audio_8000.model"
+voice_folder = "/models/tts-voices/"
 default_voice = "barack_demo.wav"
+cfg_is_no_text = true
+n_q = 24
+cfg_coef = 1.5

--- a/unmute/tts/text_to_speech.py
+++ b/unmute/tts/text_to_speech.py
@@ -109,17 +109,17 @@ AUDIO_BUFFER_SEC = 0.080 * 4
 
 
 def prepare_text_for_tts(text: str) -> str:
-    text = text.strip()
-
     unpronounceable_chars = "*_`"
     for char in unpronounceable_chars:
         text = text.replace(char, "")
 
     text = text.replace("“", '"').replace("”", '"')
     text = text.replace("‘", "'").replace("’", "'")
-    text = text.replace(" : ", " ")
 
-    return text
+    # Let's get rid entirely of ':' as it tends to make the TTS go mad.
+    text = text.replace(":", " ")
+
+    return text.strip()
 
 
 class TtsStreamingQuery(BaseModel):


### PR DESCRIPTION
Migrating from @adefossez 's PR in the old repo.

> Let's test this strong candidate for open sourcing.
> Also now getting rid of all ':' which make the TTS say out loud 'COLON'...