### PR TITLE
Cleanup and stop using local files

### DIFF
--- a/services/moshi-server/configs/tts-py.toml
+++ b/services/moshi-server/configs/tts-py.toml
@@ -6,7 +6,6 @@ authorized_ids = ["public_token"]
 [modules.tts_py]
 type = "Py"
 path = "/api/tts_streaming"
-script = "/app/moshi-server/tts.py"
 text_tokenizer_file = "hf://kyutai/unmute/test_en_fr_audio_8000.model"
 batch_size = 16
 text_bos_token = 1

--- a/services/moshi-server/configs/voice-cloning.toml
+++ b/services/moshi-server/configs/voice-cloning.toml
@@ -6,7 +6,6 @@ authorized_ids = ["public_token"]
 [modules.voice_py]
 type = "PyPost"
 path = "/api/voice"
-script = "/app/moshi-server/voice.py"
 
 [modules.voice_py.py]
-mimi_weight = "/models/e9d43d50_500_mimi_voice.safetensors"
+mimi_weight = "hf://kyutai/unmute-voice-cloning/e9d43d50_500_mimi_voice.safetensors"

--- a/swarm-deploy.yml
+++ b/swarm-deploy.yml
@@ -125,7 +125,6 @@ services:
       - moshi-server-target:/app/target
       - uv-cache:/root/.cache/uv
       - hf-cache:/root/.cache/huggingface/hub
-      - /scratch/models/:/models
       - tts-logs:/logs
     stop_grace_period: 10s # change if needed
     deploy:
@@ -154,7 +153,6 @@ services:
       - moshi-server-target:/app/target
       - uv-cache:/root/.cache/uv
       - hf-cache:/root/.cache/huggingface/hub
-      - /scratch/models/:/models
       - stt-logs:/logs
     stop_grace_period: 10s # change if needed
     deploy:
@@ -185,11 +183,13 @@ services:
   voice-cloning:
     image: rg.fr-par.scw.cloud/namespace-unruffled-tereshkova/${DOMAIN}-moshi-server:latest
     command: ["worker", "--config", "configs/voice-cloning.toml"]
+    environment:
+      - HF_TOKEN=$HUGGING_FACE_HUB_TOKEN
     volumes:
       - cargo-registry:/root/.cargo/registry
       - moshi-server-target:/app/target
       - uv-cache:/root/.cache/uv
-      - /scratch/models/:/models
+      - hf-cache:/root/.cache/huggingface/hub
       - voice-cloning-logs:/logs
     deploy:
       labels:


### PR DESCRIPTION
We don't use local files anymore, we always use HF files, meaning that if we want to deploy somewhere, we don't have to "prepare" the machine by putting specific files in it. We just deploy unmute and that's it. I also removed from the config the path to the python files, which are now automatically detected by Rust

Closes #5 