### PR TITLE
Get rid of the benchmark-llm container

### DIFF
--- a/SWARM.md
+++ b/SWARM.md
@@ -81,15 +81,6 @@ etc...
 * <https://prometheus.unmute.sh>
 * <https://portainer.unmute.sh>
 
-## Other
-
-Run the llm benchmark with
-
-```bash
-docker exec -it $(docker ps --format '{{.Names}}' | grep benchmark-llm) bash /run_bench.sh
-```
-
-
 ## Swarm services
 
 ### Main app
@@ -104,7 +95,6 @@ graph LR
     B --> LLM(LLM)
     B --> R(Redis)
     B --> V(Voice cloning)
-    Bench(Benchmark llm) --> LLM
 ```
 
 ### Monitoring

--- a/services/benchmark-llm/Dockerfile
+++ b/services/benchmark-llm/Dockerfile
@@ -1,8 +1,0 @@
-FROM ghcr.io/astral-sh/uv:0.6.17-debian AS build
-
-RUN uv run --with vllm==0.9.1 echo hello
-
-COPY run_bench.sh /
-
-
-CMD ["sleep", "infinity"]

--- a/services/benchmark-llm/run_bench.sh
+++ b/services/benchmark-llm/run_bench.sh
@@ -1,3 +1,0 @@
-set -ex
-
-uv run --with vllm==0.9.1 vllm bench serve --model google/gemma-3-12b-it --host llm --request-rate 20 --random-prefix-len 3

--- a/swarm-deploy.yml
+++ b/swarm-deploy.yml
@@ -225,16 +225,6 @@ services:
           cpus: "8"
           memory: 16G
 
-  # This service does not do anything, the only way to use it is to make a docker exec
-  # and run the benchmark script manually with:
-  # docker exec -it $(docker ps --format '{{.Names}}' | grep benchmark-llm) bash /run_bench.sh
-  benchmark-llm:
-    image: rg.fr-par.scw.cloud/namespace-unruffled-tereshkova/${DOMAIN}-benchmark-llm:latest
-    build:
-      context: services/benchmark-llm
-    environment:
-      - HUGGING_FACE_HUB_TOKEN=$HUGGING_FACE_HUB_TOKEN
-
   llm:
     image: vllm/vllm-openai:v0.9.1
     command:


### PR DESCRIPTION
We can re-introduce it if we need it later, but we weren't using it and it would often require re-uploading 8GB when deploying, which is annoying.