### PR TITLE
Dockerless: Make HTTP(S) configurable via environment variables

### DIFF
--- a/dockerless/start_backend.sh
+++ b/dockerless/start_backend.sh
@@ -2,4 +2,10 @@
 set -ex
 cd "$(dirname "$0")/.."
 
-uv run uvicorn unmute.main_websocket:app --reload --host 0.0.0.0 --port 8000 --ws-per-message-deflate=false
+UVICORN_ARGS="--reload --host 0.0.0.0 --port 8000 --ws-per-message-deflate=false"
+
+if [[ -n "$SSL_KEYFILE" && -n "$SSL_CERTFILE" ]]; then
+    UVICORN_ARGS="$UVICORN_ARGS --ssl-keyfile $SSL_KEYFILE --ssl-certfile $SSL_CERTFILE"
+fi
+
+uv run uvicorn unmute.main_websocket:app $UVICORN_ARGS

--- a/dockerless/start_frontend.sh
+++ b/dockerless/start_frontend.sh
@@ -5,4 +5,15 @@ cd "$(dirname "$0")/.."
 cd frontend
 pnpm install
 pnpm env use --global lts
-pnpm dev
+
+PNPM_ARGS=""
+
+if [[ -n "$SSL_KEYFILE" && -n "$SSL_CERTFILE" ]]; then
+    PNPM_ARGS="$PNPM_ARGS --experimental-https --experimental-https-key ../$SSL_KEYFILE --experimental-https-cert ../$SSL_CERTFILE"
+fi
+
+if [[ -n "$HTTP_HOST" ]]; then
+    PNPM_ARGS="$PNPM_ARGS -H $HTTP_HOST"
+fi
+
+pnpm dev $PNPM_ARGS

--- a/unmute/main_websocket.py
+++ b/unmute/main_websocket.py
@@ -1,3 +1,4 @@
+import os
 import asyncio
 import base64
 import json
@@ -81,6 +82,9 @@ ClientEventAdapter = TypeAdapter(
 
 # Allow CORS for local development
 CORS_ALLOW_ORIGINS = ["http://localhost", "http://localhost:3000"]
+if "HTTP_HOST" in os.environ:
+    CORS_ALLOW_ORIGINS.append(f'https://{os.environ["HTTP_HOST"]}:3000')
+
 app.add_middleware(
     CORSMiddleware,
     allow_origins=CORS_ALLOW_ORIGINS,


### PR DESCRIPTION
The following environment variables are now used:
- `HTTP_HOST`: The hostname to bind to.
- `SSL_KEYFILE`: The path to the SSL key file.
- `SSL_CERTFILE`: The path to the SSL certificate file.