### PR TITLE
Detect backend URL via env var and not port

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     volumes:
       - ./frontend/src:/app/src
     environment:
-      - NEXT_PUBLIC_BACKEND_URL=http://backend:80/api
+      - NEXT_PUBLIC_IN_DOCKER=true
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.frontend.rule=PathPrefix(`/`)"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,6 +22,8 @@ services:
       dockerfile: hot-reloading.Dockerfile
     volumes:
       - ./frontend/src:/app/src
+    environment:
+      - NEXT_PUBLIC_BACKEND_URL=http://backend:80/api
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.frontend.rule=PathPrefix(`/`)"

--- a/frontend/src/app/useBackendServerUrl.ts
+++ b/frontend/src/app/useBackendServerUrl.ts
@@ -3,24 +3,18 @@ import { useEffect, useState } from "react";
 export const useBackendServerUrl = () => {
   const [backendServerUrl, setBackendServerUrl] = useState<string | null>(null);
 
-  // Get the backend server URL. This is a bit involved to support different deployment methods.
   useEffect(() => {
+    // Prefer explicit env var if set
+    const envBackendUrl = process.env.NEXT_PUBLIC_BACKEND_URL;
+    if (envBackendUrl) {
+      setBackendServerUrl(envBackendUrl.replace(/\/$/, "")); // remove trailing slash
+      return;
+    }
+
     if (typeof window !== "undefined") {
-      const isInDocker = window.location.port !== "3000";
-
-      const prefix = isInDocker ? "/api" : "";
-
-      const url = new URL(prefix, window.location.href);
-      url.protocol = url.protocol === "http:" ? "ws" : "wss";
-      if (!isInDocker) {
-        url.port = "8000";
-      }
-
       const backendUrl = new URL("", window.location.href);
-      if (!isInDocker) {
-        backendUrl.port = "8000";
-      }
-      backendUrl.pathname = prefix;
+      backendUrl.port = "8000";
+      backendUrl.pathname = "";
       backendUrl.search = ""; // strip any query parameters
       setBackendServerUrl(backendUrl.toString().replace(/\/$/, "")); // remove trailing slash
     }

--- a/swarm-deploy.yml
+++ b/swarm-deploy.yml
@@ -60,6 +60,8 @@ services:
     image: rg.fr-par.scw.cloud/namespace-unruffled-tereshkova/${DOMAIN}-frontend:latest
     build:
       context: frontend/
+    environment:
+      - NEXT_PUBLIC_BACKEND_URL=http://backend:80/api
     deploy:
       # Having more than one replica is useful for scaling but also to avoid downtime
       # during crashes or updates. Traffic will be load balanced between replicas.
@@ -115,8 +117,8 @@ services:
         - "prometheus-port=80"
       replicas: 16
       update_config:
-        delay: 10s      # wait 10 seconds before updating the next replica
-        parallelism: 3  # update 3 replicas at a time
+        delay: 10s # wait 10 seconds before updating the next replica
+        parallelism: 3 # update 3 replicas at a time
       resources:
         # We set limits to avoid having one container taking down the whole service
         # but we don't set reservations because we do not have enough cpu/memory for this.
@@ -133,10 +135,10 @@ services:
     build:
       context: services/moshi-server
       dockerfile: private.Dockerfile
-      ssh:                          # Only needed for staging
-        - default                   # Only needed for staging
-      args:                         # Only needed for staging
-        GITHUB_ORG: $GITHUB_ORG     # Only needed for staging
+      ssh: # Only needed for staging
+        - default # Only needed for staging
+      args: # Only needed for staging
+        GITHUB_ORG: $GITHUB_ORG # Only needed for staging
     environment:
       # Env variables are grabbed from the environment of the Docker CLI, so the user deploying.
       # For security reasons, use a read-only Hugging Face token.
@@ -243,8 +245,7 @@ services:
 
   llm:
     image: vllm/vllm-openai:v0.9.1
-    command:
-      [
+    command: [
         "--model=${KYUTAI_LLM_MODEL}",
         "--max-model-len=8192",
         "--dtype=bfloat16",

--- a/swarm-deploy.yml
+++ b/swarm-deploy.yml
@@ -117,8 +117,8 @@ services:
         - "prometheus-port=80"
       replicas: 16
       update_config:
-        delay: 10s # wait 10 seconds before updating the next replica
-        parallelism: 3 # update 3 replicas at a time
+        delay: 10s      # wait 10 seconds before updating the next replica
+        parallelism: 3  # update 3 replicas at a time
       resources:
         # We set limits to avoid having one container taking down the whole service
         # but we don't set reservations because we do not have enough cpu/memory for this.
@@ -135,10 +135,10 @@ services:
     build:
       context: services/moshi-server
       dockerfile: private.Dockerfile
-      ssh: # Only needed for staging
-        - default # Only needed for staging
-      args: # Only needed for staging
-        GITHUB_ORG: $GITHUB_ORG # Only needed for staging
+      ssh:                          # Only needed for staging
+        - default                   # Only needed for staging
+      args:                         # Only needed for staging
+        GITHUB_ORG: $GITHUB_ORG     # Only needed for staging
     environment:
       # Env variables are grabbed from the environment of the Docker CLI, so the user deploying.
       # For security reasons, use a read-only Hugging Face token.
@@ -245,7 +245,8 @@ services:
 
   llm:
     image: vllm/vllm-openai:v0.9.1
-    command: [
+    command:
+      [
         "--model=${KYUTAI_LLM_MODEL}",
         "--max-model-len=8192",
         "--dtype=bfloat16",

--- a/swarm-deploy.yml
+++ b/swarm-deploy.yml
@@ -61,7 +61,7 @@ services:
     build:
       context: frontend/
     environment:
-      - NEXT_PUBLIC_BACKEND_URL=http://backend:80/api
+      - NEXT_PUBLIC_IN_DOCKER=true
     deploy:
       # Having more than one replica is useful for scaling but also to avoid downtime
       # during crashes or updates. Traffic will be load balanced between replicas.


### PR DESCRIPTION
This can be hard to debug if you forward a Docker deployment to port 3000.