### PR TITLE
Pass NEXT_PUBLIC_IN_DOCKER at build time

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,6 @@ services:
       dockerfile: hot-reloading.Dockerfile
     volumes:
       - ./frontend/src:/app/src
-    environment:
-      - NEXT_PUBLIC_IN_DOCKER=true
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.frontend.rule=PathPrefix(`/`)"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -25,6 +25,8 @@ COPY . .
 # Uncomment the following line in case you want to disable telemetry during the build.
 ENV NEXT_TELEMETRY_DISABLED=1
 
+ENV NEXT_PUBLIC_IN_DOCKER=true
+
 RUN corepack enable pnpm && pnpm run build
 
 # Production image, copy all the files and run next

--- a/frontend/hot-reloading.Dockerfile
+++ b/frontend/hot-reloading.Dockerfile
@@ -21,6 +21,7 @@ ENV NODE_ENV=development
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV HOSTNAME=0.0.0.0
 ENV PORT=3000
+ENV NEXT_PUBLIC_IN_DOCKER=true
 
 HEALTHCHECK --start-period=15s \
     CMD curl --fail http://localhost:3000/ || exit 1

--- a/frontend/src/app/useBackendServerUrl.ts
+++ b/frontend/src/app/useBackendServerUrl.ts
@@ -10,12 +10,6 @@ export const useBackendServerUrl = () => {
 
       const prefix = isInDocker ? "/api" : "";
 
-      const url = new URL(prefix, window.location.href);
-      url.protocol = url.protocol === "http:" ? "ws" : "wss";
-      if (!isInDocker) {
-        url.port = "8000";
-      }
-
       const backendUrl = new URL("", window.location.href);
       if (!isInDocker) {
         backendUrl.port = "8000";

--- a/swarm-deploy.yml
+++ b/swarm-deploy.yml
@@ -60,8 +60,6 @@ services:
     image: rg.fr-par.scw.cloud/namespace-unruffled-tereshkova/${DOMAIN}-frontend:latest
     build:
       context: frontend/
-    environment:
-      - NEXT_PUBLIC_IN_DOCKER=true
     deploy:
       # Having more than one replica is useful for scaling but also to avoid downtime
       # during crashes or updates. Traffic will be load balanced between replicas.


### PR DESCRIPTION
Turns out this env var needs to be present at build time, not just run time. It was working in docker-compose because of hot reloading but not in docker-swarm.