### PR TITLE
Fix OpenAI health check

### DIFF
--- a/unmute/main_websocket.py
+++ b/unmute/main_websocket.py
@@ -38,6 +38,7 @@ from unmute.exceptions import (
     make_ora_error,
 )
 from unmute.kyutai_constants import (
+    KYUTAI_LLM_API_KEY,
     LLM_SERVER,
     MAX_VOICE_FILE_SIZE_MB,
     SAMPLE_RATE,
@@ -110,10 +111,14 @@ def _ws_to_http(ws_url: str) -> str:
     return ws_url.replace("ws://", "http://").replace("wss://", "https://")
 
 
-def _check_server_status(server_url: str) -> bool:
+def _check_server_status(server_url: str, headers: dict | None = None) -> bool:
     """Check if the server is up by sending a GET request."""
     try:
-        response = requests.get(server_url, timeout=2)
+        response = requests.get(
+            server_url,
+            timeout=2,
+            headers=headers or {},
+        )
         logger.info(f"Response from {server_url}: {response}")
         return response.status_code == 200
     except requests.exceptions.RequestException as e:
@@ -159,7 +164,11 @@ async def _get_health(
         )
         llm_up = tg.create_task(
             asyncio.to_thread(
-                _check_server_status, _ws_to_http(LLM_SERVER) + "/v1/models"
+                _check_server_status,
+                _ws_to_http(LLM_SERVER) + "/v1/models",
+                # The default vLLM server doesn't use auth, but this is needed if you
+                # use OpenAI or another LLM server.
+                headers={"Authorization": f"Bearer {KYUTAI_LLM_API_KEY}"},
             )
         )
         voice_cloning_up = tg.create_task(


### PR DESCRIPTION
Resolves #114 

Tested via
```bash
KYUTAI_LLM_URL=https://api.openai.com KYUTAI_LLM_API_KEY=$OPENAI_API_KEY uv run fastapi dev unmute/main_websocket.py
```
followed by
```
> http http://127.0.0.1:8000/v1/health
HTTP/1.1 200 OK
content-length: 81
content-type: application/json
date: Tue, 26 Aug 2025 09:32:27 GMT
server: uvicorn

{
    "llm_up": true,
    "ok": false,
    "stt_up": false,
    "tts_up": false,
    "voice_cloning_up": false
}
```