### PR TITLE
Expose LLM server

### DIFF
--- a/bake_deploy_prod.sh
+++ b/bake_deploy_prod.sh
@@ -8,12 +8,18 @@ expected_branch="prod"
 current_branch=$(git rev-parse --abbrev-ref HEAD)
 if [[ "$current_branch" != "$expected_branch" ]]; then
   echo "❌ You are on branch '$current_branch'. Please switch to '$expected_branch' before deploying."
-  exit 1
+  read -p "Continue anyway? [y/N]: " override
+  if [[ ! "$override" =~ ^[Yy]$ ]]; then
+    exit 1
+  fi
 fi
 
 if [[ -n $(git status --porcelain) ]]; then
   echo "❌ You have uncommitted changes. Please commit or stash them before deploying."
-  exit 1
+  read -p "Continue anyway? [y/N]: " override
+  if [[ ! "$override" =~ ^[Yy]$ ]]; then
+    exit 1
+  fi
 fi
 
 set -x # Print commands

--- a/bake_deploy_prod.sh
+++ b/bake_deploy_prod.sh
@@ -25,8 +25,7 @@ fi
 set -x # Print commands
 
 export DOMAIN=unmute.sh
-# Note that using non-Mistral models also requires changing the vLLM args in ./swarm-deploy.yml
-export KYUTAI_LLM_MODEL=mistralai/Mistral-Small-3.2-24B-Instruct-2506
+export KYUTAI_LLM_MODEL=google/gemma-3-12b-it
 export DOCKER_HOST=ssh://root@${DOMAIN}
 
 echo "If you get an connection error, do: ssh root@${DOMAIN}"

--- a/swarm-deploy.yml
+++ b/swarm-deploy.yml
@@ -163,7 +163,7 @@ services:
         - "traefik.http.routers.tts.tls=true"
         - "traefik.http.routers.tts.tls.certresolver=letsencrypt_resolver"
         - "traefik.http.services.tts.loadbalancer.server.port=8080"
-        - "traefik.http.routers.tts.priority=120"
+        - "traefik.http.routers.tts.priority=100"
       replicas: 3
       update_config:
         delay: 60s # it takes a very long time to boot up and we want no downtime
@@ -206,7 +206,7 @@ services:
         - "traefik.http.routers.stt.tls=true"
         - "traefik.http.routers.stt.tls.certresolver=letsencrypt_resolver"
         - "traefik.http.services.stt.loadbalancer.server.port=8080"
-        - "traefik.http.routers.stt.priority=110"
+        - "traefik.http.routers.stt.priority=100"
       replicas: 1
       resources:
         limits:
@@ -269,6 +269,17 @@ services:
     deploy:
       labels:
         - "prometheus-port=8000"
+        # Expose the LLM service via Traefik under the /llm-server path
+        - "traefik.enable=true"
+        - "traefik.http.routers.llm.rule=(Host(`www.${DOMAIN}`) || Host(`${DOMAIN}`)) && PathPrefix(`/llm-server`)"
+        - "traefik.http.routers.llm.middlewares=strip-llm"
+        - "traefik.http.middlewares.strip-llm.replacepathregex.regex=^/llm-server/(.*)"
+        - "traefik.http.middlewares.strip-llm.replacepathregex.replacement=/$$1"
+        - "traefik.http.routers.llm.entrypoints=websecure"
+        - "traefik.http.routers.llm.tls=true"
+        - "traefik.http.routers.llm.tls.certresolver=letsencrypt_resolver"
+        - "traefik.http.services.llm.loadbalancer.server.port=8080"
+        - "traefik.http.routers.llm.priority=100"
       # 4 containers are used, one gpu per container, and the requests end up being load balanced
       # between them. There is no "smart" routing but it's enough for our use case.
       replicas: 4

--- a/swarm-deploy.yml
+++ b/swarm-deploy.yml
@@ -249,8 +249,9 @@ services:
         "--max-model-len=2048",
         "--dtype=bfloat16",
         "--tokenizer_mode=mistral",  # You can remove those args if you're not using mistral
-        # "--config_format=mistral",
-        # "--load-format=mistral",
+        "--config_format=mistral",
+        "--load-format=mistral",
+        "--gpu-memory-utilization=0.9",
       ]
     healthcheck:
       # The very first time it can be VERY slow, because of the download

--- a/swarm-deploy.yml
+++ b/swarm-deploy.yml
@@ -278,7 +278,7 @@ services:
         - "traefik.http.routers.llm.entrypoints=websecure"
         - "traefik.http.routers.llm.tls=true"
         - "traefik.http.routers.llm.tls.certresolver=letsencrypt_resolver"
-        - "traefik.http.services.llm.loadbalancer.server.port=8080"
+        - "traefik.http.services.llm.loadbalancer.server.port=8000"
         - "traefik.http.routers.llm.priority=100"
       # 4 containers are used, one gpu per container, and the requests end up being load balanced
       # between them. There is no "smart" routing but it's enough for our use case.

--- a/swarm-deploy.yml
+++ b/swarm-deploy.yml
@@ -248,9 +248,9 @@ services:
         "--model=${KYUTAI_LLM_MODEL}",
         "--max-model-len=8192",
         "--dtype=bfloat16",
-        # "--tokenizer_mode=mistral",  # You can remove those args if you're not using mistral
-        # "--config_format=mistral",
-        # "--load-format=mistral",
+        "--tokenizer_mode=mistral",  # You can remove those args if you're not using mistral
+        "--config_format=mistral",
+        "--load-format=mistral",
       ]
     healthcheck:
       # The very first time it can be VERY slow, because of the download

--- a/swarm-deploy.yml
+++ b/swarm-deploy.yml
@@ -246,12 +246,8 @@ services:
     command:
       [
         "--model=${KYUTAI_LLM_MODEL}",
-        "--max-model-len=2048",
+        "--max-model-len=8192",
         "--dtype=bfloat16",
-        "--tokenizer_mode=mistral",  # You can remove those args if you're not using mistral
-        "--config_format=mistral",
-        "--load-format=mistral",
-        "--gpu-memory-utilization=0.9",
       ]
     healthcheck:
       # The very first time it can be VERY slow, because of the download

--- a/swarm-deploy.yml
+++ b/swarm-deploy.yml
@@ -249,8 +249,8 @@ services:
         "--max-model-len=2048",
         "--dtype=bfloat16",
         "--tokenizer_mode=mistral",  # You can remove those args if you're not using mistral
-        "--config_format=mistral",
-        "--load-format=mistral",
+        # "--config_format=mistral",
+        # "--load-format=mistral",
       ]
     healthcheck:
       # The very first time it can be VERY slow, because of the download

--- a/swarm-deploy.yml
+++ b/swarm-deploy.yml
@@ -246,7 +246,7 @@ services:
     command:
       [
         "--model=${KYUTAI_LLM_MODEL}",
-        "--max-model-len=8192",
+        "--max-model-len=4096",
         "--dtype=bfloat16",
         "--tokenizer_mode=mistral",  # You can remove those args if you're not using mistral
         "--config_format=mistral",

--- a/swarm-deploy.yml
+++ b/swarm-deploy.yml
@@ -246,7 +246,7 @@ services:
     command:
       [
         "--model=${KYUTAI_LLM_MODEL}",
-        "--max-model-len=4096",
+        "--max-model-len=2048",
         "--dtype=bfloat16",
         "--tokenizer_mode=mistral",  # You can remove those args if you're not using mistral
         "--config_format=mistral",


### PR DESCRIPTION
Currently deployed on prod.

Having GPU memory issues with Mistral-Small-24B because the GPU only has 44 GB of vRAM but we'd need at least 48 GB for the weights themselves. I don't remember how come this worked before??