### PR TITLE
Fix moshi-server log locations to match containers

### DIFF
--- a/services/moshi-server/configs/stt-prod.toml
+++ b/services/moshi-server/configs/stt-prod.toml
@@ -1,5 +1,5 @@
 static_dir = "./static/"
-log_dir = "/logs"
+log_dir = "/tmp/unmute_logs"
 instance_name = "tts"
 authorized_ids = ["public_token"]
 

--- a/services/moshi-server/configs/tts-prod.toml
+++ b/services/moshi-server/configs/tts-prod.toml
@@ -1,5 +1,5 @@
 static_dir = "./static/"
-log_dir = "/logs"
+log_dir = "/tmp/unmute_logs"
 instance_name = "tts"
 authorized_ids = ["public_token"]
 
@@ -11,7 +11,7 @@ batch_size = 4  # NOTE: make this smaller if running on one GPU
 text_bos_token = 1
 
 [modules.tts_py.py]
-log_folder = "/logs"
+log_folder = "/tmp/unmute_logs"
 # We could use replace **/*.safetensors with unmute-prod-website/*.safetensors
 # to only get the voices used in Unmute, but we are using the TTS for the demo
 # on the project page too and for that we want to load the other voices as well

--- a/services/moshi-server/configs/voice-cloning.toml
+++ b/services/moshi-server/configs/voice-cloning.toml
@@ -1,5 +1,5 @@
 static_dir = "./static/"
-log_dir = "/logs"
+log_dir = "/tmp/unmute_logs"
 instance_name = "voice"
 authorized_ids = ["public_token"]
 

--- a/swarm-deploy.yml
+++ b/swarm-deploy.yml
@@ -147,7 +147,7 @@ services:
       - moshi-server-target:/app/target
       - uv-cache:/root/.cache/uv
       - hf-cache:/root/.cache/huggingface/hub
-      - tts-logs:/logs
+      - tts-logs:/tmp/unmute_logs
     stop_grace_period: 10s # change if needed
     deploy:
       labels:
@@ -190,7 +190,7 @@ services:
       - moshi-server-target:/app/target
       - uv-cache:/root/.cache/uv
       - hf-cache:/root/.cache/huggingface/hub
-      - stt-logs:/logs
+      - stt-logs:/tmp/unmute_logs
     stop_grace_period: 10s # change if needed
     deploy:
       labels:
@@ -229,7 +229,7 @@ services:
       - moshi-server-target:/app/target
       - uv-cache:/root/.cache/uv
       - hf-cache:/root/.cache/huggingface/hub
-      - voice-cloning-logs:/logs
+      - voice-cloning-logs:/tmp/unmute_logs
     deploy:
       labels:
         - "prometheus-port=8080"


### PR DESCRIPTION
Changes swarm-deploy.yml to mount /tmp/unmute_logs, which is where the logs actually are in the container