### PR TITLE
Fix silence-marker cleanup in LLM message preprocessing

### DIFF
--- a/tests/test_llm_utils.py
+++ b/tests/test_llm_utils.py
@@ -1,6 +1,6 @@
 import pytest
 
-from unmute.llm.llm_utils import rechunk_to_words
+from unmute.llm.llm_utils import preprocess_messages_for_llm, rechunk_to_words
 
 
 async def make_iterator(s: str):
@@ -36,3 +36,17 @@ async def test_rechunk_to_words():
     assert await f(" they are ok") == [" they", " are", " ok"]
     assert await f("  foo bar") == [" foo", " bar"]
     assert await f(" \t foo  bar") == [" foo", " bar"]
+
+
+def test_preprocess_messages_for_llm_removes_user_silence_marker_from_output_only():
+    chat_history = [
+        {"role": "system", "content": "You are concise."},
+        {"role": "user", "content": "...hello again"},
+        {"role": "assistant", "content": "Sure."},
+    ]
+
+    processed = preprocess_messages_for_llm(chat_history)
+
+    assert processed[1]["content"] == "hello again"
+    # Ensure the original chat history is not mutated.
+    assert chat_history[1]["content"] == "...hello again"

--- a/unmute/llm/llm_utils.py
+++ b/unmute/llm/llm_utils.py
@@ -46,7 +46,7 @@ def preprocess_messages_for_llm(
         # messages, so add a dummy user message.
         output = [output[0]] + [{"role": "user", "content": "Hello."}] + output[1:]
 
-    for message in chat_history:
+    for message in output:
         if (
             message["role"] == "user"
             and message["content"].startswith(USER_SILENCE_MARKER)


### PR DESCRIPTION
## What changed
- Fixed `preprocess_messages_for_llm` so user silence marker cleanup is applied to the processed output messages (instead of iterating over the original input list).
- Added a regression test to verify:
  - `"...<text>"` is normalized to `<text>` in returned user messages.
  - the original `chat_history` input is not mutated.

## Why
- The previous implementation deep-copied messages into `output`, but then iterated over `chat_history` when removing `USER_SILENCE_MARKER` prefixes.
- That meant the returned messages still contained the marker, while the input could be mutated unexpectedly.
- This patch makes behavior match the function’s intent and comments.

## Testing
- ✅ `source .venv/bin/activate && pytest -q`
  - Result: `3 passed`
